### PR TITLE
doc: Fix a link that was interpreted as a title

### DIFF
--- a/doc/yaml_configuration.md
+++ b/doc/yaml_configuration.md
@@ -345,8 +345,8 @@ is likely that you'll end up with significant breakage, such as most
 snapshots failing to work.
 
 Note: since Stack v2.1.3, `ignore-expiry` was changed to `true` by
-default. For more information on this change, see [issue
-#4928](https://github.com/commercialhaskell/stack/issues/4928).
+default. For more information on this change, see
+[issue #4928](https://github.com/commercialhaskell/stack/issues/4928).
 
 ### system-ghc
 


### PR DESCRIPTION
The rendering of this is funny:  https://docs.haskellstack.org/en/stable/yaml_configuration/#4928httpsgithubcomcommercialhaskellstackissues4928


![sc-2019-08-13T10:52:21-04:00](https://user-images.githubusercontent.com/2515201/62951758-8389f780-bdb8-11e9-9431-a16529c9bf73.png)